### PR TITLE
Build Command, Output Dir, Ignored Build Step

### DIFF
--- a/models.go
+++ b/models.go
@@ -14,16 +14,19 @@ type GetProjectsResponse struct {
 }
 
 type Project struct {
-	Id            string          `json:"id"`
-	Name          string          `json:"name"`
-	Framework     string          `json:"framework"`
-	RootDirectory string         `json:"rootDirectory"`
-	NodeVersion   string          `json:"nodeVersion"`
-	AccountId     string          `json:"accountId"`
-	UpdatedAt     int64           `json:"updatedAt"`
-	CreatedAt     int64           `json:"createdAt"`
-	Alias         []*Domain       `json:"alias"`
-	Link          *RepositoryLink `json:"link"`
+	Id                          string          `json:"id"`
+	Name                        string          `json:"name"`
+	Framework                   string          `json:"framework"`
+	RootDirectory               string          `json:"rootDirectory"`
+	NodeVersion                 string          `json:"nodeVersion"`
+	AccountId                   string          `json:"accountId"`
+	UpdatedAt                   int64           `json:"updatedAt"`
+	CreatedAt                   int64           `json:"createdAt"`
+	Alias                       []*Domain       `json:"alias"`
+	Link                        *RepositoryLink `json:"link"`
+	BuildCommand                string          `json:"buildCommand"`
+	OutputDirectory             string          `json:"outputDirectory"`
+	CommandForIgnoringBuildStep string          `json:"commandForIgnoringBuildStep,omitempty"`
 }
 
 type RepositoryLink struct {
@@ -33,18 +36,24 @@ type RepositoryLink struct {
 }
 
 type CreateProjectOptions struct {
-	Name           string
-	Framework      string
-	RepositoryType string
-	RepositoryName string
-	RootDirectory  string
+	Name                        string
+	Framework                   string
+	RepositoryType              string
+	RepositoryName              string
+	RootDirectory               string
+	BuildCommand                string
+	OutputDirectory             string
+	CommandForIgnoringBuildStep string
 }
 
 type CreateProjectRequest struct {
-	Name          string                `json:"name"`
-	Framework     string                `json:"framework"`
-	RootDirectory *string               `json:"rootDirectory"`
-	GitRepository *GitRepositoryRequest `json:"gitRepository,omitempty"`
+	Name                        string                `json:"name"`
+	Framework                   string                `json:"framework"`
+	RootDirectory               *string               `json:"rootDirectory"`
+	GitRepository               *GitRepositoryRequest `json:"gitRepository,omitempty"`
+	BuildCommand                string                `json:"buildCommand"`
+	OutputDirectory             string                `json:"outputDirectory"`
+	CommandForIgnoringBuildStep string                `json:"commandForIgnoringBuildStep,omitempty"`
 }
 
 type GitRepositoryRequest struct {
@@ -53,8 +62,11 @@ type GitRepositoryRequest struct {
 }
 
 type UpdateProjectRequest struct {
-	Framework     string  `json:"framework"`
-	RootDirectory *string `json:"rootDirectory"`
+	Framework                   string  `json:"framework"`
+	RootDirectory               *string `json:"rootDirectory"`
+	BuildCommand                string  `json:"buildCommand"`
+	OutputDirectory             string  `json:"outputDirectory"`
+	CommandForIgnoringBuildStep string  `json:"commandForIgnoringBuildStep"`
 }
 
 type CreateProjectEnvRequest struct {

--- a/projects.go
+++ b/projects.go
@@ -23,8 +23,11 @@ func (p *ProjectApi) CreateProject(ctx context.Context, options *CreateProjectOp
 	u := p.baseUrl.ResolveReference(rel)
 
 	body := &CreateProjectRequest{
-		Name:          options.Name,
-		Framework:     options.Framework,
+		Name:                        options.Name,
+		Framework:                   options.Framework,
+		BuildCommand:                options.BuildCommand,
+		OutputDirectory:             options.OutputDirectory,
+		CommandForIgnoringBuildStep: options.CommandForIgnoringBuildStep,
 	}
 
 	if options.RepositoryType != "" && options.RepositoryName != "" {
@@ -88,7 +91,10 @@ func (p *ProjectApi) UpdateProject(ctx context.Context, name string, project *Pr
 	u := p.baseUrl.ResolveReference(rel)
 
 	body := &UpdateProjectRequest{
-		Framework:     project.Framework,
+		Framework:                   project.Framework,
+		BuildCommand:                project.BuildCommand,
+		OutputDirectory:             project.OutputDirectory,
+		CommandForIgnoringBuildStep: project.CommandForIgnoringBuildStep,
 	}
 
 	if project.RootDirectory != "" {


### PR DESCRIPTION
## Context

A common way to store front-end code is in a mono-repo format. Vercel is able to host colocated projects through the use of a few configuration options (In conjunction with several already supported):

1. Build command - for running builds on directories that are not the root project, eg. a shared library
2. Output Directory - specifying the path to the output'd build
3. Ignored build step - for specifying when _not_ to run the build, eg. on changes to a directory not relevant to the current app

## Work done

Added support for the above fields