### PR TITLE
Fix build command and output directory

### DIFF
--- a/models.go
+++ b/models.go
@@ -51,8 +51,8 @@ type CreateProjectRequest struct {
 	Framework                   string                `json:"framework"`
 	RootDirectory               *string               `json:"rootDirectory"`
 	GitRepository               *GitRepositoryRequest `json:"gitRepository,omitempty"`
-	BuildCommand                string                `json:"buildCommand"`
-	OutputDirectory             string                `json:"outputDirectory"`
+	BuildCommand                string                `json:"buildCommand,omitempty"`
+	OutputDirectory             string                `json:"outputDirectory,omitempty"`
 	CommandForIgnoringBuildStep string                `json:"commandForIgnoringBuildStep,omitempty"`
 }
 
@@ -64,8 +64,8 @@ type GitRepositoryRequest struct {
 type UpdateProjectRequest struct {
 	Framework                   string  `json:"framework"`
 	RootDirectory               *string `json:"rootDirectory"`
-	BuildCommand                string  `json:"buildCommand"`
-	OutputDirectory             string  `json:"outputDirectory"`
+	BuildCommand                *string  `json:"buildCommand"`
+	OutputDirectory             *string  `json:"outputDirectory"`
 	CommandForIgnoringBuildStep string  `json:"commandForIgnoringBuildStep"`
 }
 

--- a/projects.go
+++ b/projects.go
@@ -92,9 +92,17 @@ func (p *ProjectApi) UpdateProject(ctx context.Context, name string, project *Pr
 
 	body := &UpdateProjectRequest{
 		Framework:                   project.Framework,
-		BuildCommand:                project.BuildCommand,
-		OutputDirectory:             project.OutputDirectory,
+		BuildCommand:                nil,
+		OutputDirectory:             nil,
 		CommandForIgnoringBuildStep: project.CommandForIgnoringBuildStep,
+	}
+
+	if project.BuildCommand != "" {
+		body.BuildCommand = &project.BuildCommand
+	}
+
+	if project.OutputDirectory != "" {
+		body.OutputDirectory = &project.OutputDirectory
 	}
 
 	if project.RootDirectory != "" {


### PR DESCRIPTION
## Context

When creating a project with the `buildCommand` in one of the following three states:

1. Not present
2. `buildCommand: ""`
3. `buildCommand: null`

The `Build Command` setting is turned off. The response to the request _always_ includes `buildCommand: ""`. 

Sending the received `buildCommand: ""` back as part of an update request results in the `Build Command` override being enabled with an empty value.

The `Output Directory` override acts in the same way.

This makes it very difficult to work with, given the inconsistent meaning of `""` in the Project API. Especially for stateful mechanisms such as Terraform.

## Work Done

1. We now omit both the `buildCommand` and `outputDirectory` on creation if they are empty.
2. We now send `buildCommand: null` and `outputDirectory: null` when they are set as empty strings on the `Project` model.