### PR TITLE
Send null for framework when creating and updating

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ func New() (*Client, error) {
 
 	baseUrl := &url.URL{
 		Scheme: "https",
-		Host: "api.vercel.com",
+		Host:   "api.vercel.com",
 	}
 
 	return &Client{

--- a/default_client.go
+++ b/default_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	MissingTokenError  = errors.New("missing Vercel API token")
+	MissingTokenError = errors.New("missing Vercel API token")
 )
 
 type transport struct {

--- a/models.go
+++ b/models.go
@@ -48,7 +48,7 @@ type CreateProjectOptions struct {
 
 type CreateProjectRequest struct {
 	Name                        string                `json:"name"`
-	Framework                   *string                `json:"framework"`
+	Framework                   *string               `json:"framework"`
 	RootDirectory               *string               `json:"rootDirectory"`
 	GitRepository               *GitRepositoryRequest `json:"gitRepository,omitempty"`
 	BuildCommand                string                `json:"buildCommand,omitempty"`
@@ -62,10 +62,10 @@ type GitRepositoryRequest struct {
 }
 
 type UpdateProjectRequest struct {
-	Framework                   *string  `json:"framework"`
+	Framework                   *string `json:"framework"`
 	RootDirectory               *string `json:"rootDirectory"`
-	BuildCommand                *string  `json:"buildCommand"`
-	OutputDirectory             *string  `json:"outputDirectory"`
+	BuildCommand                *string `json:"buildCommand"`
+	OutputDirectory             *string `json:"outputDirectory"`
 	CommandForIgnoringBuildStep string  `json:"commandForIgnoringBuildStep"`
 }
 

--- a/models.go
+++ b/models.go
@@ -48,7 +48,7 @@ type CreateProjectOptions struct {
 
 type CreateProjectRequest struct {
 	Name                        string                `json:"name"`
-	Framework                   string                `json:"framework"`
+	Framework                   *string                `json:"framework"`
 	RootDirectory               *string               `json:"rootDirectory"`
 	GitRepository               *GitRepositoryRequest `json:"gitRepository,omitempty"`
 	BuildCommand                string                `json:"buildCommand,omitempty"`
@@ -62,7 +62,7 @@ type GitRepositoryRequest struct {
 }
 
 type UpdateProjectRequest struct {
-	Framework                   string  `json:"framework"`
+	Framework                   *string  `json:"framework"`
 	RootDirectory               *string `json:"rootDirectory"`
 	BuildCommand                *string  `json:"buildCommand"`
 	OutputDirectory             *string  `json:"outputDirectory"`

--- a/projects.go
+++ b/projects.go
@@ -24,10 +24,13 @@ func (p *ProjectApi) CreateProject(ctx context.Context, options *CreateProjectOp
 
 	body := &CreateProjectRequest{
 		Name:                        options.Name,
-		Framework:                   options.Framework,
 		BuildCommand:                options.BuildCommand,
 		OutputDirectory:             options.OutputDirectory,
 		CommandForIgnoringBuildStep: options.CommandForIgnoringBuildStep,
+	}
+
+	if options.Framework != "" {
+		body.Framework = &options.Framework
 	}
 
 	if options.RepositoryType != "" && options.RepositoryName != "" {
@@ -91,10 +94,13 @@ func (p *ProjectApi) UpdateProject(ctx context.Context, name string, project *Pr
 	u := p.baseUrl.ResolveReference(rel)
 
 	body := &UpdateProjectRequest{
-		Framework:                   project.Framework,
 		BuildCommand:                nil,
 		OutputDirectory:             nil,
 		CommandForIgnoringBuildStep: project.CommandForIgnoringBuildStep,
+	}
+
+	if project.Framework != "" {
+		body.Framework = &project.Framework
 	}
 
 	if project.BuildCommand != "" {


### PR DESCRIPTION
## Context

To change a Vercel project to a framework type of "Other", we need to send framework as an explicit `null`.

## Work done

1. The internal DTOs for creating an updating the framework are now pointers
2. These pointers are only set if the `framework` being specified is not a 0 value
3. Ran `go fmt`